### PR TITLE
Clone config when inheriting

### DIFF
--- a/lib/dry/configurable.rb
+++ b/lib/dry/configurable.rb
@@ -40,7 +40,7 @@ module Dry
     def inherited(subclass)
       subclass.instance_variable_set(:@_config_mutex, @_config_mutex)
       subclass.instance_variable_set(:@_settings, @_settings)
-      subclass.instance_variable_set(:@_config, @_config) if defined?(@_config)
+      subclass.instance_variable_set(:@_config, @_config.clone) if defined?(@_config)
       super
     end
 

--- a/lib/dry/configurable.rb
+++ b/lib/dry/configurable.rb
@@ -38,8 +38,8 @@ module Dry
 
     # @private
     def inherited(subclass)
-      subclass.instance_variable_set(:@_config_mutex, @_config_mutex)
-      subclass.instance_variable_set(:@_settings, @_settings)
+      subclass.instance_variable_set(:@_config_mutex, Mutex.new)
+      subclass.instance_variable_set(:@_settings, @_settings.clone)
       subclass.instance_variable_set(:@_config, @_config.clone) if defined?(@_config)
       super
     end

--- a/spec/support/shared_examples/configurable.rb
+++ b/spec/support/shared_examples/configurable.rb
@@ -92,6 +92,16 @@ RSpec.shared_examples 'a configurable class' do
             expect(klass.config.dsn).to eq('jdbc:sqlite:memory')
           end
         end
+
+        context 'when the inherited settings are modified' do
+          before do
+            subclass.setting :db
+          end
+
+          it 'does not modify the original' do
+            expect(klass._settings.keys).to_not include(:db)
+          end
+        end
       end
     end
   end

--- a/spec/support/shared_examples/configurable.rb
+++ b/spec/support/shared_examples/configurable.rb
@@ -80,6 +80,18 @@ RSpec.shared_examples 'a configurable class' do
         it 'retains its configuration' do
           expect(subclass.config.dsn).to eq('jdbc:sqlite:memory')
         end
+
+        context 'when the inherited config is modified' do
+          before do
+            subclass.configure do |config|
+              config.dsn = 'jdbc:sqlite:file'
+            end
+          end
+
+          it 'does not modify the original' do
+            expect(klass.config.dsn).to eq('jdbc:sqlite:memory')
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
When a `Configurable` is subclassed, if the config of the subclass gets modified, it will overwrite the parent's config. This fixes the issue.